### PR TITLE
-p is bad

### DIFF
--- a/docs/15_mapping.ipynb
+++ b/docs/15_mapping.ipynb
@@ -330,7 +330,7 @@
    "outputs": [],
    "source": [
     "# Create a directory \n",
-    "mkdir -p ../bam \n",
+    "mkdir ../bam \n",
     "# Change directory \n",
     "cd ../bam "
    ]


### PR DESCRIPTION
`-p` is bad for the beginners

Because you can create a bunch of folder with a mispelling without any warning.

My 2 cents